### PR TITLE
Replace template README with Virtual Dietitian documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,335 +1,293 @@
-# AI/ML Project Template
+# Virtual Dietitian
 
-Professional template for AI agent and ML projects with clean architecture, Docker support, and development best practices.
+AI-powered nutrition analysis agent built with Google Cloud Agent Builder. Analyzes meal descriptions and provides personalized nutritional feedback with actionable health insights.
+
+**Live Demo:** https://storage.googleapis.com/virtual-dietitian-demo/index.html
+
+## Overview
+
+Virtual Dietitian is a conversational AI agent that:
+- Analyzes natural language meal descriptions
+- Calculates total nutritional values (calories, protein, carbs, fat, fiber, vitamins, minerals)
+- Provides evidence-based health recommendations
+- Detects nutritional imbalances and suggests improvements
+- Supports 500,000+ foods via USDA FoodData Central API integration
+
+Built as a demonstration of rapid prototyping with serverless architecture and AI agents.
+
+## Architecture
+
+### Components
+
+**Cloud Function Webhook** (`cloud-functions/nutrition-analyzer/`)
+- Python 3.12 serverless function
+- Parses meal descriptions and calculates nutrition
+- Implements tiered rule engine for health insights
+- 100% test coverage with pytest
+
+**Vertex AI Agent Builder**
+- Natural language understanding (NLU)
+- Conversational flow management
+- Natural language generation (NLG)
+- Integrates with webhook for deterministic business logic
+
+**Data Sources**
+1. **Static Database** (47 foods) - Fast lookup for common foods
+2. **USDA API** (500,000+ foods) - Fallback for comprehensive coverage
+
+### Design Philosophy
+
+**Separation of Concerns:**
+- LLM handles conversation and language understanding
+- Cloud Function handles deterministic nutrition calculations
+- Rule engine provides consistent health recommendations
+
+**Scalability:**
+- Serverless-first architecture (Cloud Functions Gen2)
+- Scales from 1 to 1M users without code changes
+- Stateless design for MVP (session state planned for Phase 2)
 
 ## Quick Start
 
 ### Prerequisites
-- Python 3.11+
+- Python 3.12+
+- Google Cloud SDK (`gcloud`)
+- Active GCP project
 
-### Initial Setup
+### Local Development
 
-1. **Clone and customize:**
+1. **Setup environment:**
    ```bash
-   git clone https://github.com/adamkwhite/project_template my-ai-project
-   cd my-ai-project
-   # Update project name in pyproject.toml, docker-compose.yaml
+   cd cloud-functions/nutrition-analyzer
+   python3 -m venv virtual-dietitian-venv
+   source virtual-dietitian-venv/bin/activate
+   pip install -r requirements.txt
    ```
 
-2. **Environment configuration:**
+2. **Configure environment variables:**
    ```bash
    cp .env.example .env
-   # Edit .env with your API keys (OpenAI, LangSmith, etc.)
+   # Edit .env with your USDA API key (optional)
    ```
 
-3. **Install dependencies:**
+3. **Run tests:**
    ```bash
-   # Production dependencies
-   pip install -r requirements.txt
-
-   # Development dependencies (testing, linting, formatting)
-   pip install -r requirements-dev.txt
+   pytest --cov=. --cov-report=html
    ```
 
-4. **Run with Docker:**
+4. **Test locally:**
    ```bash
-   docker-compose up --build
+   python3 test_usda_local.py
    ```
+
+### Deployment
+
+**Deploy Cloud Function:**
+```bash
+# Without USDA API (static DB only)
+gcloud functions deploy nutrition-analyzer \
+  --gen2 \
+  --runtime=python312 \
+  --region=us-central1 \
+  --source=. \
+  --entry-point=analyze_nutrition \
+  --trigger-http \
+  --allow-unauthenticated
+
+# With USDA API integration
+./scripts/deploy_function_with_usda.sh YOUR_USDA_API_KEY
+```
+
+**Deploy Demo Page:**
+```bash
+# Create GCS bucket (one-time)
+gsutil mb -l us-central1 gs://virtual-dietitian-demo
+
+# Upload demo page
+gsutil cp docs/demo/virtual-dietitian-demo.html gs://virtual-dietitian-demo/index.html
+
+# Make public
+gsutil iam ch allUsers:objectViewer gs://virtual-dietitian-demo
+```
 
 ## Project Structure
 
 ```
-project_template/
-├── .github/
-│   └── workflows/              # CI/CD pipelines (pytest, Docker build)
+Virtual-Dietitian/
+├── cloud-functions/
+│   └── nutrition-analyzer/          # Cloud Function webhook
+│       ├── main.py                   # Entry point (HTTP handler)
+│       ├── nutrition_calculator.py   # Nutrition aggregation logic
+│       ├── rule_engine.py            # Health insight rules
+│       ├── usda_client.py            # USDA API integration
+│       ├── nutrition_db.json         # Static food database (47 foods)
+│       ├── requirements.txt          # Python dependencies
+│       ├── test_*.py                 # Unit tests (100% coverage)
+│       └── .env.example              # Environment variable template
 │
-├── .claude/                    # Claude AI custom commands
-│   ├── commands/
-│   │   ├── StartOfTheDay.md
-│   │   └── WrapUpForTheDay.md
-│   └── settings.local.json
-│
-├── src/
-│   └── your_agent/
-│       ├── __init__.py
-│       ├── config.py           # Global configuration
-│       │
-│       ├── domain/             # DOMAIN LAYER - Business logic
-│       │   ├── __init__.py
-│       │   ├── models.py       # Pydantic models, state definitions
-│       │   ├── exceptions.py   # Custom exceptions
-│       │   ├── tools/          # Custom tools/functions
-│       │   ├── prompts/        # Prompt templates
-│       │   └── utils.py        # Shared utilities
-│       │
-│       ├── application/        # APPLICATION LAYER - Orchestration
-│       │   ├── __init__.py
-│       │   ├── agents/         # Agent workflows
-│       │   │   ├── chat_agent.py
-│       │   │   ├── research_agent.py
-│       │   │   └── task_agent.py
-│       │   └── chains/         # Reusable processing chains
-│       │
-│       └── infrastructure/     # INFRASTRUCTURE LAYER - External services
-│           ├── __init__.py
-│           ├── api/            # REST/GraphQL endpoints
-│           │   └── main.py     # FastAPI/Flask app
-│           ├── llm/            # LLM provider clients
-│           ├── storage/        # Database/vector store
-│           └── monitoring/     # Logging/observability
-│
-├── tests/
-│   ├── __init__.py
-│   ├── conftest.py             # Pytest fixtures
-│   ├── unit/                   # Fast unit tests (no external deps)
-│   ├── integration/            # Integration tests (testcontainers)
-│   └── e2e/                    # End-to-end workflow tests
+├── agent-config/                     # Vertex AI Agent Builder config
+│   ├── agent-instructions.txt        # Agent prompt and behavior
+│   ├── webhook-config.json           # Webhook integration settings
+│   └── test-cases.md                 # Manual test scenarios
 │
 ├── docs/
-│   ├── architecture.md         # System design decisions
-│   ├── deployment.md           # AWS/GCP deployment guides
-│   └── ai-docs/                # AI-assisted development guides
-│       ├── generate-tasks.md
-│       ├── create-prd.md
-│       └── process-task-list.md
+│   ├── demo/
+│   │   ├── virtual-dietitian-demo.html  # Live demo page
+│   │   └── demo-script.md               # Demo walkthrough
+│   ├── deployment/                      # Deployment guides
+│   └── features/                        # PRDs and planning docs
 │
 ├── scripts/
-│   ├── setup.sh                # Initial environment setup
-│   ├── build.sh                # Docker build automation
-│   └── deploy.sh               # Deployment scripts
+│   └── deploy_function_with_usda.sh  # Automated deployment
 │
-├── data/                       # Local data files (gitignored)
-├── notebooks/                  # Jupyter notebooks for experiments
-│
-├── .env.example                # Environment variable template
-├── .gitignore
-├── CLAUDE.md                   # Project context for Claude AI
-├── docker-compose.yaml
-├── Dockerfile
-├── Makefile                    # Build/run shortcuts
-├── pyproject.toml              # Python project config
-├── requirements.txt            # Production dependencies
-├── requirements-dev.txt        # Development dependencies
-├── LICENSE
-└── README.md
+├── CLAUDE.md                         # Project context for Claude AI
+└── README.md                         # This file
 ```
 
-## Architecture Overview
+## Features
 
-### Three-Layer Design
+### Phase 1 (MVP) - ✅ Complete
+- [x] 47-food static nutrition database
+- [x] Natural language meal parsing
+- [x] Nutritional analysis (9 nutrients tracked)
+- [x] Tiered rule engine (3 rule types)
+- [x] Cloud Function webhook deployment
+- [x] Vertex AI Agent Builder integration
+- [x] 100% test coverage
+- [x] Demo page with Dialogflow Messenger widget
 
-**Domain Layer** (`src/your_agent/domain/`)
-- Core business logic and rules
-- Framework-agnostic (no LangChain/LangGraph coupling)
-- Custom tools, prompts, state models
-- Pure Python, highly testable
+### Phase 2 (Current) - 🚧 In Progress
+- [x] USDA FoodData Central API integration (500,000+ foods)
+- [x] Feature flag for gradual rollout
+- [ ] Enhanced error handling and logging
+- [ ] Performance optimization (caching)
 
-**Application Layer** (`src/your_agent/application/`)
-- Workflow orchestration (agents, chains, graphs)
-- Coordinates domain logic
-- Handles agent-to-agent communication
-- Can use LangChain, LangGraph, or custom frameworks
+### Phase 3 (Planned)
+- [ ] Multi-turn conversations with context
+- [ ] Meal history tracking
+- [ ] Dietary goal setting and monitoring
+- [ ] Personalized recommendations
+- [ ] Export nutrition reports
 
-**Infrastructure Layer** (`src/your_agent/infrastructure/`)
-- External service integrations (LLMs, databases, APIs)
-- API endpoints (FastAPI/Flask)
-- Monitoring and observability
-- Deployment-specific code
+## Technology Stack
 
-### Understanding Domain vs Application
+- **Backend:** Python 3.12, Flask
+- **Cloud Platform:** Google Cloud Platform
+  - Cloud Functions Gen2 (serverless compute)
+  - Vertex AI Agent Builder (conversational AI)
+  - Cloud Storage (static hosting)
+- **APIs:** USDA FoodData Central API
+- **Testing:** pytest, pytest-cov
+- **Deployment:** gcloud CLI, bash scripts
 
-**Domain Layer = "What your agent knows"**
+## Testing
 
-Business logic independent of any framework. Examples:
-
-```python
-# domain/tools/calculator.py
-def calculate_mortgage(principal: float, rate: float, years: int) -> float:
-    """Pure business logic - no LLM, no LangChain"""
-    monthly_rate = rate / 12 / 100
-    num_payments = years * 12
-    return principal * (monthly_rate * (1 + monthly_rate)**num_payments) / \
-           ((1 + monthly_rate)**num_payments - 1)
-
-# domain/models.py
-from pydantic import BaseModel
-
-class CustomerQuery(BaseModel):
-    question: str
-    customer_id: str
-    priority: str
-
-# domain/prompts/templates.py
-MORTGAGE_ADVISOR_PROMPT = """You are a mortgage advisor.
-Customer context: {customer_history}
-Question: {question}
-Provide clear, compliant advice."""
-```
-
-**Application Layer = "How your agent uses it"**
-
-Framework-specific orchestration that ties domain logic together:
-
-```python
-# application/agents/mortgage_agent.py
-from langgraph.graph import StateGraph
-from domain.tools.calculator import calculate_mortgage
-from domain.prompts.templates import MORTGAGE_ADVISOR_PROMPT
-
-def build_mortgage_agent():
-    """Uses domain logic in a LangGraph workflow"""
-    graph = StateGraph()
-    graph.add_node("calculate", lambda state: {
-        "payment": calculate_mortgage(
-            state["principal"],
-            state["rate"],
-            state["years"]
-        )
-    })
-    # ... rest of workflow
-```
-
-**When to put code in Domain vs Application:**
-
-Put in **Domain** if it's:
-- Business rules (mortgage calculations, risk scoring)
-- Data models (Pydantic models, state definitions)
-- Custom tools that don't need LLM (parsers, validators, formatters)
-- Prompt templates (just strings)
-- Exceptions specific to your business (InvalidLoanAmount)
-- Utilities (date formatting for your industry)
-
-Put in **Application** if it's:
-- Agent graphs/chains
-- Routing logic between agents
-- LLM-based decision making
-- Workflow state machines
-- Multi-agent coordination
-
-**The test:** If you deleted LangChain/LangGraph tomorrow and switched to raw OpenAI, would this code still be useful?
-- Yes → Domain
-- No → Application
-
-**Benefits:**
-- Easy to test (mock external services)
-- Swap frameworks without rewriting business logic
-- Clear separation of concerns
-- Scales from prototype to production
-
-## Development Workflow
-
-### Running Tests
+### Run Tests
 ```bash
-# Unit tests (fast, no external dependencies)
-pytest tests/unit -v
-
-# Integration tests (uses Docker testcontainers)
-pytest tests/integration -v
-
-# All tests with coverage
-pytest --cov=src --cov-report=html
-
-# View coverage report
-open htmlcov/index.html
+cd cloud-functions/nutrition-analyzer
+pytest --cov=. --cov-report=html
 ```
 
-### Code Quality
+### Test Coverage
+- **Overall:** 100% coverage
+- **Core modules:**
+  - `nutrition_calculator.py` - 100%
+  - `rule_engine.py` - 100%
+  - `main.py` - 100%
+
+### Manual Testing
 ```bash
-# Format code
-black src/ tests/
-
-# Lint
-ruff check src/ tests/
-
-# Type checking
-mypy src/
+# Test deployed function
+curl -X POST https://nutrition-analyzer-epp4v6loga-uc.a.run.app \
+  -H "Content-Type: application/json" \
+  -d '{"food_items":[{"name":"chicken","quantity":1},{"name":"rice","quantity":1}]}'
 ```
 
-### Docker Development
-```bash
-# Build and run
-docker-compose up --build
+## Configuration
 
-# Run specific service
-docker-compose up agent-api
+### Environment Variables
 
-# Rebuild after dependency changes
-docker-compose up --build --force-recreate
+**Required for USDA API:**
+- `ENABLE_USDA_API` - Enable USDA API fallback (default: false)
+- `USDA_API_KEY` - API key from https://fdc.nal.usda.gov/api-key-signup.html
 
-# View logs
-docker-compose logs -f agent-api
+**Optional:**
+- `ENVIRONMENT` - Environment name (local/cloud)
+- `LOG_EXECUTION_ID` - Enable execution ID logging (default: false)
+- `NUTRITION_DB_PATH` - Path to static database JSON
+
+### Get USDA API Key
+1. Visit https://fdc.nal.usda.gov/api-key-signup.html
+2. Sign up for free API key
+3. Add to `.env` or deployment script
+
+## API Reference
+
+### Webhook Endpoint
+
+**POST** `/analyze_nutrition`
+
+**Request Body:**
+```json
+{
+  "food_items": [
+    {"name": "chicken", "quantity": 1},
+    {"name": "rice", "quantity": 1}
+  ]
+}
 ```
 
-### Makefile Shortcuts
-```bash
-make install      # Install dependencies
-make test         # Run all tests
-make lint         # Run linting and type checks
-make format       # Format code with black
-make docker-up    # Start Docker services
-make docker-down  # Stop Docker services
-make clean        # Clean cache files
+**Response:**
+```json
+{
+  "total_nutrition": {
+    "calories": 330.0,
+    "protein_g": 35.0,
+    "carbs_g": 28.0,
+    "fat_g": 5.6,
+    "fiber_g": 0.4,
+    "sodium_mg": 149.0,
+    "vitamin_c_mg": 0.0,
+    "calcium_mg": 25.0,
+    "iron_mg": 1.7
+  },
+  "macro_percentages": {
+    "protein_pct": 42,
+    "carbs_pct": 34,
+    "fat_pct": 15
+  },
+  "insights": [
+    {
+      "type": "recommendation",
+      "message": "This meal is low in fiber. Consider adding vegetables..."
+    }
+  ],
+  "follow_up": "Would you like ideas for adding more vegetables?"
+}
 ```
 
-## Environment Variables
+## Performance
 
-Key variables in `.env`:
+- **Static DB lookup:** < 50ms
+- **USDA API fallback:** 1-2 seconds
+- **Cold start:** 2-3 seconds (Cloud Function)
+- **Warm requests:** < 100ms
 
-```bash
-# LLM Provider
-OPENAI_API_KEY=sk-...
-ANTHROPIC_API_KEY=sk-ant-...
+## Contributing
 
-# Observability
-LANGSMITH_API_KEY=ls_...
-LANGSMITH_PROJECT=my-project
-
-# Infrastructure
-DATABASE_URL=postgresql://user:pass@localhost/db
-REDIS_URL=redis://localhost:6379
-
-# Application
-LOG_LEVEL=INFO
-ENVIRONMENT=development
-```
-
-## Deployment
-
-### AWS EC2 (t2.small)
-```bash
-# 1. SSH into instance
-ssh ubuntu@your-ec2-ip
-
-# 2. Clone and setup
-git clone <your-repo> && cd <repo>
-cp .env.example .env
-# Edit .env with production values
-
-# 3. Run with Docker
-docker-compose -f docker-compose.prod.yaml up -d
-```
-
-See `docs/deployment.md` for detailed AWS, GCP, Azure guides.
-
-## Project Customization Checklist
-
-When starting a new project from this template:
-
-- [ ] Update `pyproject.toml` with project name
-- [ ] Rename `src/your_agent/` to actual project name
-- [ ] Update `docker-compose.yaml` service names
-- [ ] Configure `.env` with actual API keys
-- [ ] Update README title and description
-- [ ] Add project-specific docs to `docs/`
-- [ ] Configure CI/CD in `.github/workflows/`
-- [ ] Update `CLAUDE.md` with project context
-- [ ] Update `LICENSE` file
-
-## Git Configuration
-
-Default branch: `main`
-GitHub user: `adamkwhite`
+This is a demonstration project. For production use, consider:
+- Adding authentication and user accounts
+- Implementing rate limiting
+- Adding meal history persistence
+- Expanding rule engine with more health insights
+- Supporting dietary restrictions (vegan, gluten-free, etc.)
 
 ## License
 
 MIT License - See [LICENSE](LICENSE)
+
+## Maintainer
+
+**Adam White** ([@adamkwhite](https://github.com/adamkwhite))
+
+Built as a technical demonstration for interview process.


### PR DESCRIPTION
## Summary
Replaces generic AI/ML template README with project-specific Virtual Dietitian documentation.

## Changes
- Project-specific title and description
- Live demo link at the top
- Virtual Dietitian architecture (Cloud Functions, Vertex AI, USDA API)
- Actual deployment commands
- API reference with real endpoints
- Performance metrics
- Phase roadmap showing current progress

## Removes
- Generic "AI/ML Project Template" content
- LangChain/LangGraph references
- Three-layer architecture explanation
- Placeholder project names

## Impact
Makes GitHub README accurately represent the Virtual Dietitian project instead of showing template boilerplate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)