### PR TITLE
End-of-day cleanup: Update CLAUDE.md with Session 7 learnings

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,9 +25,9 @@ Build a conversational AI agent that analyzes meal descriptions and provides nut
 - **Scalability:** Serverless-first design (1 to 1M users without architectural changes)
 
 ## Current Status
-**Implementation Status:** MVP COMPLETE (Sessions 1-5 done)
+**Implementation Status:** Phase 2 COMPLETE (Sessions 1-7 done)
 **Current Branch:** main
-**Last Updated:** October 13, 2025
+**Last Updated:** October 14, 2025
 
 ### Completed Sessions
 - ✅ Session 1: GCP Setup & Environment Configuration
@@ -35,29 +35,55 @@ Build a conversational AI agent that analyzes meal descriptions and provides nut
 - ✅ Session 3: Cloud Function Webhook Development
 - ✅ Session 4: Vertex AI Agent Builder Configuration
 - ✅ Session 5: End-to-End Testing & Demo Preparation
+- ✅ Session 6: Agent Builder Integration & Live Deployment
+- ✅ Session 7: Code Quality & SonarCloud Integration
 
 ### Key Deliverables
 - ✅ Cloud Function deployed: `nutrition-analyzer` (us-central1)
-- ✅ Nutrition database: 47 foods across 6 categories
+- ✅ Nutrition database: 47 foods + USDA API (500,000+ foods)
 - ✅ Tiered rule engine with 3 rule types
-- ✅ Unit tests: 100% coverage, all passing
+- ✅ Unit tests: 32 tests, 100% coverage on core modules (44.8% overall)
 - ✅ Agent Builder configuration complete
 - ✅ Demo script and test cases documented
+- ✅ SonarCloud integration with CI/CD pipeline
+- ✅ Demo page deployed to GCS
+
+### Recent Changes (Session 7 - October 14, 2025)
+- Added SonarCloud integration for code quality analysis
+- Set up GitHub Actions two-stage CI/CD pipeline
+- Fixed all code formatting violations (black, isort, flake8)
+- Added comprehensive code quality badges to README
+- Fixed documentation discrepancies (test coverage, tech stack, API docs)
+- Created PROJECT_STATUS.md for accurate project tracking
+- Identified technical debt: USDA client needs test coverage (Issue #7)
 
 ## Technology Stack
-- **Backend:** Python 3.12, Flask (Cloud Functions Gen2)
-- **Testing:** pytest, pytest-cov (100% coverage)
+- **Backend:** Python 3.12, Google Cloud Functions Framework (not Flask - see notes below)
+- **Testing:** pytest, pytest-cov
+- **Code Quality:** SonarCloud, black, isort, flake8, pre-commit hooks
+- **CI/CD:** GitHub Actions (linting → testing → code analysis)
 - **Cloud Platform:** Google Cloud Platform
-  - Cloud Functions Gen2 (HTTP trigger)
-  - Vertex AI Agent Builder
-  - Vertex AI Search
-- **Data:** Static JSON (47 foods, USDA-based values)
+  - Cloud Functions Gen2 (serverless compute)
+  - Vertex AI Agent Builder (conversational AI)
+  - Cloud Storage (static website hosting)
+- **APIs:** USDA FoodData Central API (500,000+ foods)
+- **Data:** Static JSON (47 foods) + USDA API fallback
 - **Deployment:** gcloud CLI, bash scripts
 
+### Technology Notes
+**Why Functions Framework (not Flask)?**
+- We use `@functions_framework.http` decorator (Google's official framework)
+- Flask is a transitive dependency, only import `jsonify()` utility
+- Functions Framework handles GCP Cloud Functions integration automatically
+- Simpler deployment, no WSGI/routing configuration needed
+- Perfect fit for serverless webhook endpoints
+
 ## Key Files
+- **Status:** `docs/PROJECT_STATUS.md` (current project state)
 - **PRD:** `docs/features/virtual-dietitian-mvp-PLANNED/prd.md`
-- **Todo List:** `docs/todo.md`
-- **Nutrition Data:** `data/nutrition_db.json`
+- **Nutrition Data:**
+  - `data/nutrition_db.json` (master copy)
+  - `cloud-functions/nutrition-analyzer/nutrition_db.json` (deployed copy)
 - **Webhook:** `cloud-functions/nutrition-analyzer/`
   - `main.py` - Entry point (202 lines)
   - `nutrition_calculator.py` - Aggregation (237 lines)
@@ -71,11 +97,52 @@ Build a conversational AI agent that analyzes meal descriptions and provides nut
 - **Demo:** `docs/demo/demo-script.md`
 - **Documentation:** `docs/deployment/`, `docs/demo/`
 
+## Known Issues
+- **Issue #6:** SonarCloud GitHub Action is deprecated (needs migration to sonarqube-scan-action)
+- **Issue #7:** USDA client module has 0% test coverage (brings overall coverage to 44.8%)
+- USDA API feature flag is enabled but requires API key configuration
+- Manual test scripts (`manual_test_*.py`) require API keys and environment setup
+
+## Next Steps
+**Immediate (Technical Debt):**
+- Add comprehensive unit tests for `usda_client.py` to reach ~90%+ coverage
+- Migrate to non-deprecated SonarCloud action
+
+**Phase 3 (Planned Features):**
+- Multi-turn conversations with context tracking
+- Meal history persistence (database integration)
+- Dietary goal setting and progress monitoring
+- Personalized recommendations based on user patterns
+- Export nutrition reports (PDF, CSV)
+
+## Dependencies
+**External Services:**
+- GCP Cloud Functions (Python 3.12 runtime)
+- Vertex AI Agent Builder
+- USDA FoodData Central API (optional, feature-flagged)
+- SonarCloud (code quality analysis)
+
+**Python Libraries:**
+- functions-framework==3.* (Cloud Functions integration)
+- requests==2.* (HTTP client for USDA API)
+- python-dotenv==1.* (environment variables)
+- pytest==8.*, pytest-cov==6.* (testing)
+
 ## Live Demo
 **Demo URL:** https://storage.googleapis.com/virtual-dietitian-demo/index.html
 **Cloud Function:** https://nutrition-analyzer-epp4v6loga-uc.a.run.app
 **GCP Project:** virtualdietitian
 **Region:** us-central1
+**SonarCloud:** https://sonarcloud.io/summary/new_code?id=adamkwhite_Virtual-Dietitian
+
+## Lessons Learned
+**Session 7 Key Learnings:**
+1. **Workflow Discipline:** Always use feature branches, even for documentation changes
+2. **Quality Gates:** SonarCloud "Previous version" needs 2+ analyses to establish baseline
+3. **Documentation Accuracy:** Regular deep reviews prevent documentation drift
+4. **Technology Clarity:** Be precise about frameworks (Functions Framework vs Flask)
+5. **Test Coverage Reality:** Distinguish between "core module coverage" and "overall coverage"
+6. **Pre-commit Hooks:** Never bypass with environment variables (PRE_COMMIT_ALLOW_NO_CONFIG=1)
 
 ## Maintainer
 adamkwhite


### PR DESCRIPTION
## Summary
End-of-day documentation update for Session 7.

Updates CLAUDE.md with accurate project status, technology stack corrections, and key learnings from today's work.

## Changes Made

### Current Status Updates
- Phase 2 COMPLETE (Sessions 1-7)
- Added Session 6 and Session 7 to completed sessions list
- Updated key deliverables (USDA API, SonarCloud, demo page)
- Added Recent Changes section documenting Session 7 work

### Technology Stack Corrections
- **Corrected:** Flask → Google Cloud Functions Framework
- Added explanation of why Functions Framework (not Flask)
- Added code quality tools (SonarCloud, black, isort, flake8)
- Added CI/CD pipeline details (GitHub Actions)

### New Sections
- **Known Issues:** Issues #6, #7 documented
- **Next Steps:** Technical debt + Phase 3 roadmap
- **Dependencies:** External services + Python libraries with versions
- **Lessons Learned:** 6 key insights from Session 7

### Key Files Updates
- Added PROJECT_STATUS.md reference (current tracking)
- Documented dual nutrition database locations (master + deployed)

## Lessons Learned (Critical)

1. **Workflow Discipline:** Always use feature branches, even for docs
2. **Quality Gates:** SonarCloud "Previous version" needs 2+ analyses
3. **Documentation Accuracy:** Regular reviews prevent drift
4. **Technology Clarity:** Be precise (Functions Framework ≠ Flask)
5. **Test Coverage Reality:** Core modules (100%) vs overall (44.8%)
6. **Pre-commit Hooks:** Never bypass with environment variables

## Test Plan
- ✅ Pre-commit hooks passed (trailing whitespace, EOF, etc.)
- ✅ No code changes, documentation only
- ✅ Markdown formatting verified

## Checklist
- [x] Updated CLAUDE.md with accurate project status
- [x] Documented Session 7 learnings
- [x] Added new sections (Known Issues, Dependencies, Lessons Learned)
- [x] Corrected technology stack (Functions Framework)
- [x] Stored learnings in claude-memory MCP
- [x] Followed feature branch workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)