### PR TITLE
Fix Issue #6: Migrate to sonarqube-scan-action@v6

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -69,7 +69,7 @@ jobs:
 
       - name: SonarCloud Scan
         if: github.actor != 'dependabot[bot]'
-        uses: SonarSource/sonarcloud-github-action@master
+        uses: SonarSource/sonarqube-scan-action@v6
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,5 +1,6 @@
 sonar.projectKey=adamkwhite_Virtual-Dietitian
 sonar.organization=adamkwhite
+sonar.host.url=https://sonarcloud.io
 sonar.python.version=3.12
 sonar.python.coverage.reportPaths=cloud-functions/nutrition-analyzer/coverage.xml
 sonar.sources=cloud-functions/nutrition-analyzer


### PR DESCRIPTION
## Summary
Migrate from deprecated `sonarcloud-github-action@master` to officially supported `sonarqube-scan-action@v6` to resolve Issue #6.

## Problem
The `SonarSource/sonarcloud-github-action` has been officially deprecated by SonarSource and users are instructed to migrate to `sonarqube-scan-action`.

## Solution
**Updated Files:**
1. `.github/workflows/build.yml` - Replace deprecated action with `sonarqube-scan-action@v6`
2. `sonar-project.properties` - Add explicit `sonar.host.url=https://sonarcloud.io`

**Changes:**
```yaml
# Before
uses: SonarSource/sonarcloud-github-action@master

# After  
uses: SonarSource/sonarqube-scan-action@v6
```

## Benefits of v6
- **Better Security:** Rewritten from Bash to JavaScript to prevent command-line injection
- **Official Support:** Maintained action with latest features and bug fixes
- **Better Compatibility:** Optimized for GitHub-hosted runners (utilities pre-installed)
- **Version Pinning:** Using `@v6` instead of `@master` for reproducible builds

## Configuration
Added `sonar.host.url=https://sonarcloud.io` to `sonar-project.properties` to explicitly configure SonarCloud endpoint. This ensures the action correctly targets SonarCloud (not self-hosted SonarQube).

## Testing
This PR will test the new configuration:
- ✅ Quick Validation (linting) should pass
- ✅ Tests & SonarCloud Analysis should pass  
- ✅ SonarCloud Code Analysis should now succeed (previously failing due to deprecated action)

## References
- **Deprecation Notice:** https://github.com/SonarSource/sonarcloud-github-action
- **New Action:** https://github.com/SonarSource/sonarqube-scan-action
- **Documentation:** https://docs.sonarsource.com/sonarqube-cloud/advanced-setup/ci-based-analysis/github-actions-for-sonarcloud
- **Release Notes:** https://github.com/SonarSource/sonarqube-scan-action/releases/tag/v6.0.0

## Related
Closes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)