### PR TITLE
fix(sonar): exclude usda_client.py from coverage analysis

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -5,3 +5,4 @@ sonar.python.version=3.12
 sonar.python.coverage.reportPaths=cloud-functions/nutrition-analyzer/coverage.xml
 sonar.sources=cloud-functions/nutrition-analyzer
 sonar.exclusions=**/*test*.py,**/__pycache__/**,htmlcov/**,**/virtual-dietitian-venv/**,**/.pytest_cache/**,notebooks/**
+sonar.coverage.exclusions=**/usda_client.py


### PR DESCRIPTION
## Problem
`usda_client.py` is appearing in SonarCloud coverage analysis despite being feature-flagged off, causing 0% coverage and failing the quality gate.

The file was previously excluded in `pyproject.toml` for pytest coverage, but SonarCloud doesn't read that configuration.

## Solution
Add `sonar.coverage.exclusions=**/usda_client.py` to `sonar-project.properties` to exclude the file from SonarCloud coverage analysis.

## Implementation
- Added coverage exclusion to `sonar-project.properties:8`

## Acceptance Criteria
- [x] SonarCloud configuration updated
- [x] Commit follows conventional commit format
- [x] Pre-commit hooks pass

## Related
- Original coverage exclusion: `pyproject.toml` `[tool.coverage.run]` omit config
- Feature flag: USDA API integration disabled (Session 10)

🤖 Generated with [Claude Code](https://claude.com/claude-code)