### PR TITLE
fix(sonar): remove duplicate stopwords in parser

### DIFF
--- a/cloud-functions/nutrition-analyzer/main.py
+++ b/cloud-functions/nutrition-analyzer/main.py
@@ -99,12 +99,9 @@ def parse_meal_description(meal_description: str):
         "jai",
         "ai",
         "et",
-        "de",
         "des",
         "le",
-        "la",
         "les",
-        "un",
         "une",
         "du",
         "avec",
@@ -114,16 +111,16 @@ def parse_meal_description(meal_description: str):
         "y",
         "con",
         "el",
-        "la",
         "los",
         "las",
-        "un",
         "una",
-        "de",
         "del",
-        "comí",
         "comi",
-        "comí",
+        # Shared French/Spanish
+        "de",  # French: "of/from", Spanish: "of/from"
+        "la",  # French: "the" (feminine), Spanish: "the" (feminine)
+        "un",  # French: "a/an" (masculine), Spanish: "a/an" (masculine)
+        "comí",  # Spanish: "I ate" (with accent)
     }
     # Normalize: lowercase, remove extra punctuation
     text = meal_description.lower()


### PR DESCRIPTION
## Summary
- Removed duplicate stopword entries: `de`, `la`, `un`, `comí`
- Reorganized stopwords into language-specific sections (English, French, Spanish)
- Added new "Shared French/Spanish" section for words appearing in both languages
- Resolves SonarCloud code smell: duplicate dictionary keys in `main.py:73-127`

## Changes
**File:** `cloud-functions/nutrition-analyzer/main.py:73-124`
- Removed duplicate `"la"` (was in both French and Spanish sections)
- Removed duplicate `"un"` (was in both French and Spanish sections)
- Removed duplicate `"de"` (was in both French and Spanish sections)
- Removed duplicate `"comí"` (appeared twice in Spanish section)
- Added explanatory comments for shared words

## Test Plan
- [x] Pre-commit hooks pass (black, ruff, ruff-format)
- [ ] SonarCloud analysis passes (will verify after PR creation)
- [ ] No functional changes - stopwords set has identical runtime behavior

## Related
- Resolves SonarCloud code smell flagged in quality gate

🤖 Generated with [Claude Code](https://claude.com/claude-code)